### PR TITLE
Clarifying return types in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Like above, but returns an array of 3 numbers between 0 and 1, for the r, g, and
 
 **husl.fromHex(hex)**
 
-Takes a hex string and returns the HUSL color as array of 3 numbers between 0 and 1 for the hue, saturation and lightness channel. 
+Takes a hex string and returns the HUSL color as array that contains the hue (0-360), saturation(0-100) and lightness(0-100) channel.
+_Note_: The result can have rounding errors. For example saturation can be 100.00000000000007
 
 **husl.fromRGB(red, green, blue)**
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Server-side: ``npm install husl``.
 
 **husl.toRGB(hue, saturation, lightness)**
 
-Like above, but returns an array of 3 numbers between 0 and 1, for each RGB channel.
+Like above, but returns an array of 3 numbers between 0 and 1, for the r, g, and b channel.
 
 **husl.fromHex(hex)**
 
-Takes a hex string and returns the HUSL color as defined above.
+Takes a hex string and returns the HUSL color as array of 3 numbers between 0 and 1 for the hue, saturation and lightness channel. 
 
 **husl.fromRGB(red, green, blue)**
 


### PR DESCRIPTION
The current API documentation left me a little wondering what the actual return type is so I had to test even after reading the docs. This textual improvement would have helped me, maybe it helps others.